### PR TITLE
Add optional action to run `tfsec` on a repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ To run:
 docker run --rm -it -v "$(pwd):/workdir" tfsec .
 ```
 
+## Use as an actions
+
+If you want to run tfsec on your repository as an action, you can use the https://github.com/triat/terraform-security-scan which is using `tfsec` the same way you would in local but with an action that you described on your repository.
+
 ## Features
 
 - Checks for sensitive data inclusion across all providers


### PR DESCRIPTION
Hello,

I found your tool recently and I totally loved it. As I use terraform regularly, I thought it would be nice to have such a tool as a security checker when someone does a PR on our repos.

This is why I'd like to propose to add a line to reference my action in your README, such that people who want to do the same as me, have already a way to do it and do not struggle to develop it.

Of course, as I'm only reusing your tool, I'm totally open to adapt my version if you think there is something wrong.

Thanks for your time and your tool.

Tom