### PR TITLE
[GKE check] Add check for legacy abac (attribute-based access control)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ there are also checks which are provider agnostic.
 | GCP002  | google   | Unencrypted storage bucket.
 | GCP003  | google   | An inbound firewall rule allows traffic from `/0`.
 | GCP004  | google   | An outbound firewall rule allows traffic to `/0`.
+| GCP005  | google   | Legacy ABAC permissions are enabled.
 
 ## Running in CI
 

--- a/go.mod
+++ b/go.mod
@@ -31,8 +31,6 @@ require (
 	github.com/liamg/clinch v1.0.0
 	github.com/liamg/tml v0.2.0
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/pelletier/go-toml v1.6.0 // indirect
 	github.com/prometheus/client_golang v1.2.1 // indirect

--- a/internal/app/tfsec/checks/gke_abac_enabled.go
+++ b/internal/app/tfsec/checks/gke_abac_enabled.go
@@ -1,0 +1,33 @@
+package checks
+
+import (
+	"fmt"
+
+	"github.com/liamg/tfsec/internal/app/tfsec/parser"
+	"github.com/liamg/tfsec/internal/app/tfsec/scanner"
+)
+
+// GkeAbacEnabled See https://github.com/liamg/tfsec#included-checks for check info
+const GkeAbacEnabled scanner.CheckCode = "GCP005"
+
+func init() {
+	scanner.RegisterCheck(scanner.Check{
+		Code:           GkeAbacEnabled,
+		RequiredTypes:  []string{"resource"},
+		RequiredLabels: []string{"google_container_cluster"},
+		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
+
+			enable_legacy_abac := block.GetAttribute("enable_legacy_abac")
+			if enable_legacy_abac.Value().AsString() == "true" {
+				return []scanner.Result{
+					check.NewResult(
+						fmt.Sprintf("Resource '%s' defines a cluster with ABAC enabled. Disable and rely on RBAC instead. https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#leave_abac_disabled_default_for_110", block.Name()),
+						block.Range(),
+					),
+				}
+			}
+
+			return nil
+		},
+	})
+}

--- a/internal/app/tfsec/gke_abac_enabled_test.go
+++ b/internal/app/tfsec/gke_abac_enabled_test.go
@@ -1,0 +1,37 @@
+package tfsec
+
+import (
+	"testing"
+
+	"github.com/liamg/tfsec/internal/app/tfsec/scanner"
+
+	"github.com/liamg/tfsec/internal/app/tfsec/checks"
+)
+
+func Test_GkeAbacEnabled(t *testing.T) {
+
+	var tests = []struct {
+		name                  string
+		source                string
+		mustIncludeResultCode scanner.CheckCode
+		mustExcludeResultCode scanner.CheckCode
+	}{
+		{
+			name: "check google_container_cluster with enable_legacy_abac set to true",
+			source: `
+resource "google_container_cluster" "gke" {
+	enable_legacy_abac = "true"
+	
+}`,
+			mustIncludeResultCode: checks.GkeAbacEnabled,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			results := scanSource(test.source)
+			assertCheckCode(t, test.mustIncludeResultCode, test.mustExcludeResultCode, results)
+		})
+	}
+
+}


### PR DESCRIPTION
Adds a GKE check that ensures that legacy abac is disabled.

> In Kubernetes, RBAC is used to grant permissions to resources at the cluster and namespace level. RBAC allows you to define roles with rules containing a set of permissions. RBAC has significant security advantages and is now stable in Kubernetes, so it’s time to disable ABAC.
https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#leave_abac_disabled_default_for_110