### PR TITLE
Add check for msk unencrypted data in transit

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ there are also checks which are provider agnostic.
 | AWS018  | aws      | Missing description for security group/security group rule.
 | AWS019  | aws      | A KMS key is not configured to auto-rotate
 | AWS020  | aws      | CloudFront distribution allows unencrypted (HTTP) communications.
+| AWS022  | aws      | A MSK cluster allows unencrypted data in transit.
 | AZU001  | azurerm  | An inbound network security rule allows traffic from `/0`.
 | AZU002  | azurerm  | An outbound network security rule allows traffic to `/0`.
 | AZU003  | azurerm  | Unencrypted managed disk.

--- a/internal/app/tfsec/aws_unencrypted_msk_broker_transit_test.go
+++ b/internal/app/tfsec/aws_unencrypted_msk_broker_transit_test.go
@@ -1,0 +1,91 @@
+package tfsec
+
+import (
+	"testing"
+
+	"github.com/liamg/tfsec/internal/app/tfsec/scanner"
+
+	"github.com/liamg/tfsec/internal/app/tfsec/checks"
+)
+
+func Test_AWSUnencryptedMSKBroker(t *testing.T) {
+	var tests = []struct {
+		name                  string
+		source                string
+		mustIncludeResultCode scanner.RuleID
+		mustExcludeResultCode scanner.RuleID
+	}{
+		{
+			name:                  "check MSK broker with encryption_info not set",
+			source:                `resource "aws_msk_cluster" "msk-cluster" {}`,
+			mustIncludeResultCode: checks.AWSUnencryptedMSKBroker,
+		},
+		{
+			name: "check MSK broker with encryption_in_transit not set",
+			source: `
+resource "aws_msk_cluster" "msk-cluster" {
+	encryption_info {
+		encryption_in_transit {
+			client_broker = "TLS_PLAINTEXT"
+			in_cluster = true
+		}
+	}
+}`,
+			mustIncludeResultCode: checks.AWSUnencryptedMSKBroker,
+		},
+		{
+			name: "check MSK broker with client_broker not set",
+			source: `
+resource "aws_msk_cluster" "msk-cluster" {
+	encryption_info {
+		encryption_in_transit {
+		}
+	}
+}`,
+			mustIncludeResultCode: checks.AWSUnencryptedMSKBroker,
+		},
+		{
+			name: "check MSK broker with client_broker set to PLAINTEXT",
+			source: `
+resource "aws_msk_cluster" "msk-cluster" {
+	encryption_info {
+		encryption_in_transit {
+			client_broker = "PLAINTEXT"
+		}
+	}
+}`,
+			mustIncludeResultCode: checks.AWSUnencryptedMSKBroker,
+		},
+		{
+			name: "check MSK broker with client_broker set to TLS_PLAINTEXT",
+			source: `
+resource "aws_msk_cluster" "msk-cluster" {
+	encryption_info {
+		encryption_in_transit {
+			client_broker = "TLS_PLAINTEXT"
+		}
+	}
+}`,
+			mustIncludeResultCode: checks.AWSUnencryptedMSKBroker,
+		},
+		{
+			name: "check MSK broker with client_broker set to TLS",
+			source: `
+resource "aws_msk_cluster" "msk-cluster" {
+	encryption_info {
+		encryption_in_transit {
+			client_broker = "TLS"
+		}
+	}
+}`,
+			mustExcludeResultCode: checks.AWSUnencryptedMSKBroker,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			results := scanSource(test.source)
+			assertCheckCode(t, test.mustIncludeResultCode, test.mustExcludeResultCode, results)
+		})
+	}
+}

--- a/internal/app/tfsec/checks/aws_unencrypted_msk_broker_transit.go
+++ b/internal/app/tfsec/checks/aws_unencrypted_msk_broker_transit.go
@@ -1,0 +1,78 @@
+package checks
+
+import (
+	"fmt"
+
+	"github.com/liamg/tfsec/internal/app/tfsec/scanner"
+
+	"github.com/liamg/tfsec/internal/app/tfsec/parser"
+)
+
+// AWSUnencryptedMSKBroker See https://github.com/liamg/tfsec#included-checks for check info
+const AWSUnencryptedMSKBroker scanner.RuleID = "AWS021"
+
+func init() {
+	scanner.RegisterCheck(scanner.Check{
+		Code:           AWSUnencryptedMSKBroker,
+		RequiredTypes:  []string{"resource"},
+		RequiredLabels: []string{"aws_msk_cluster"},
+		CheckFunc: func(check *scanner.Check, block *parser.Block, context *scanner.Context) []scanner.Result {
+
+			var results []scanner.Result
+
+			defaultBehaviorBlock := block.GetBlock("encryption_info")
+			if defaultBehaviorBlock == nil {
+				results = append(results,
+					check.NewResult(
+						fmt.Sprintf("Resource '%s' defines a MSK cluster that allows plaintext as well as TLS encrypted data in transit (missing encryption_info block).", block.Name()),
+						block.Range(),
+						scanner.SeverityWarning,
+					),
+				)
+			} else if defaultBehaviorBlock != nil {
+				encryptionInTransit := defaultBehaviorBlock.GetBlock("encryption_in_transit")
+				if encryptionInTransit == nil {
+					results = append(results,
+						check.NewResult(
+							fmt.Sprintf("Resource '%s' defines a MSK cluster that allows plaintext as well as TLS encrypted data in transit (missing encryption_in_transit block).", block.Name()),
+							block.Range(),
+							scanner.SeverityWarning,
+						),
+					)
+				} else {
+					clientBroker := encryptionInTransit.GetAttribute("client_broker")
+					if clientBroker == nil {
+						results = append(results,
+							check.NewResult(
+								fmt.Sprintf("Resource '%s' defines a MSK cluster that allows plaintext as well as TLS encrypted data in transit (missing client_broker block).", block.Name()),
+								block.Range(),
+								scanner.SeverityWarning,
+							),
+						)
+					} else if clientBroker != nil && clientBroker.Value().AsString() == "PLAINTEXT" {
+						results = append(results,
+							check.NewResultWithValueAnnotation(
+								fmt.Sprintf("Resource '%s' defines a MSK cluster that only allows plaintext data in transit.", block.Name()),
+								clientBroker.Range(),
+								clientBroker,
+								scanner.SeverityError,
+							),
+						)
+					} else if clientBroker != nil && clientBroker.Value().AsString() == "TLS_PLAINTEXT" {
+						results = append(results,
+							check.NewResultWithValueAnnotation(
+								fmt.Sprintf("Resource '%s' defines a MSK cluster  that allows plaintext as well as TLS encrypted data in transit.", block.Name()),
+								clientBroker.Range(),
+								clientBroker,
+								scanner.SeverityWarning,
+							),
+						)
+					}
+				}
+			}
+
+			return results
+
+		},
+	})
+}


### PR DESCRIPTION
Add check for plaintext communication for MSK clusters.

Using code AWS022 as AWS021 is used in https://github.com/liamg/tfsec/pull/80 