### PR TITLE
Added new argument to disable particular checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 
 # ignore windows compiled binary
 tfsec.exe
+.vscode/launch.json

--- a/README.md
+++ b/README.md
@@ -100,6 +100,15 @@ resource "aws_security_group_rule" "my-rule" {
 If you're not sure which line to add the comment on, just check the
 tfsec output for the line number of the discovered problem.
 
+## Disable checks
+
+You may wish to exclude some checks from running. If you'd like to do so, you can
+simply add new argument `-e CHECK1,CHECK2,etc` to your cmd command
+
+```bash
+tfsec . -e GEN001,GCP001,GCP002
+```
+
 ## Included Checks
 
 Currently, checks are mostly limited to AWS/Azure/GCP resources, but

--- a/cmd/tfsec/main.go
+++ b/cmd/tfsec/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/liamg/tfsec/internal/app/tfsec/formatters"
 
@@ -19,12 +20,14 @@ import (
 var showVersion = false
 var disableColours = false
 var format string
+var excludedChecks string
 
 func init() {
 	rootCmd.Flags().BoolVar(&disableColours, "no-colour", disableColours, "Disable coloured output")
 	rootCmd.Flags().BoolVar(&disableColours, "no-color", disableColours, "Disable colored output (American style!)")
 	rootCmd.Flags().BoolVarP(&showVersion, "version", "v", showVersion, "Show version information and exit")
 	rootCmd.Flags().StringVarP(&format, "format", "f", format, "Select output format: default, json, csv, checkstyle")
+	rootCmd.Flags().StringVarP(&excludedChecks, "exclude", "e", excludedChecks, "Provide checks via , without space to exclude from run.")
 }
 
 func main() {
@@ -53,6 +56,8 @@ var rootCmd = &cobra.Command{
 
 		var dir string
 		var err error
+		var excludedChecksList []string
+
 		if len(args) == 1 {
 			dir, err = filepath.Abs(args[0])
 		} else {
@@ -61,6 +66,10 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
+		}
+
+		if len(excludedChecks) > 0 {
+			excludedChecksList = strings.Split(excludedChecks, ",")
 		}
 
 		formatter, err := getFormatter()
@@ -75,7 +84,7 @@ var rootCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		results := scanner.New().Scan(blocks)
+		results := scanner.New().Scan(blocks, excludedChecksList)
 		if err := formatter(results); err != nil {
 			fmt.Println(err)
 			os.Exit(1)

--- a/internal/app/tfsec/scanner/scanner.go
+++ b/internal/app/tfsec/scanner/scanner.go
@@ -17,15 +17,26 @@ func New() *Scanner {
 	return &Scanner{}
 }
 
+// Find element in list
+func checkInList(code RuleID, list []string) bool {
+	codeCurrent := fmt.Sprintf("%s", code)
+	for _, codeIgnored := range list {
+		if codeIgnored == codeCurrent {
+			return true
+		}
+	}
+	return false
+}
+
 // Scan takes all available hcl blocks and an optional context, and returns a slice of results. Each result indicates a potential security problem.
-func (scanner *Scanner) Scan(blocks []*parser.Block) []Result {
+func (scanner *Scanner) Scan(blocks []*parser.Block, excludedChecksList []string) []Result {
 	var results []Result
 	context := &Context{blocks: blocks}
 	for _, block := range blocks {
 		for _, check := range GetRegisteredChecks() {
 			if check.IsRequiredForBlock(block) {
 				for _, result := range check.Run(block, context) {
-					if !scanner.checkRangeIgnored(result.RuleID, result.Range) {
+					if !scanner.checkRangeIgnored(result.RuleID, result.Range) && !checkInList(result.RuleID, excludedChecksList) {
 						result.Link = fmt.Sprintf("https://github.com/liamg/tfsec/wiki/%s", result.RuleID)
 						results = append(results, result)
 					}


### PR DESCRIPTION
Dear Liam,

may I ask you to review my Pull request. This is my first attempt to write on Go so you can find my solution not so elegant as need to be.

Idea is to disable/ignore globally particular checks. For example we integrate your tool in some of our projects and its file findings for all K8S resources which contains word 'secret'.

This is very annoying and will be nice to have possibility to disable particular checks. Also it will be helpful to disable some Cloud Provider's checks if you use only one Cloud Provider.

Thanks