### PR TITLE
Added new arguments to exclude some checks globaly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 
 # ignore windows compiled binary
 tfsec.exe
+.vscode/launch.json

--- a/README.md
+++ b/README.md
@@ -100,6 +100,15 @@ resource "aws_security_group_rule" "my-rule" {
 If you're not sure which line to add the comment on, just check the
 tfsec output for the line number of the discovered problem.
 
+## Disable checks
+
+You may wish to exclude some checks from running. If you'd like to do so, you can
+simply add new argument `-e CHECK1,CHECK2,etc` to your cmd command
+
+```bash
+tfsec . -e GEN001,GCP001,GCP002
+```
+
 ## Included Checks
 
 Currently, checks are mostly limited to AWS/Azure/GCP resources, but

--- a/cmd/tfsec/main.go
+++ b/cmd/tfsec/main.go
@@ -84,7 +84,7 @@ var rootCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		results := scanner.New().Scan(blocks)
+		results := scanner.New().Scan(blocks, excludedChecksList)
 		if err := formatter(results); err != nil {
 			fmt.Println(err)
 			os.Exit(1)

--- a/cmd/tfsec/main.go
+++ b/cmd/tfsec/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/liamg/tfsec/internal/app/tfsec/formatters"
 
@@ -19,12 +20,14 @@ import (
 var showVersion = false
 var disableColours = false
 var format string
+var excludedChecks string
 
 func init() {
 	rootCmd.Flags().BoolVar(&disableColours, "no-colour", disableColours, "Disable coloured output")
 	rootCmd.Flags().BoolVar(&disableColours, "no-color", disableColours, "Disable colored output (American style!)")
 	rootCmd.Flags().BoolVarP(&showVersion, "version", "v", showVersion, "Show version information and exit")
 	rootCmd.Flags().StringVarP(&format, "format", "f", format, "Select output format: default, json, csv, checkstyle")
+	rootCmd.Flags().StringVarP(&excludedChecks, "exclude", "e", excludedChecks, "Provide checks via , without space to exclude from run.")
 }
 
 func main() {
@@ -53,6 +56,8 @@ var rootCmd = &cobra.Command{
 
 		var dir string
 		var err error
+		var excludedChecksList []string
+
 		if len(args) == 1 {
 			dir, err = filepath.Abs(args[0])
 		} else {
@@ -61,6 +66,10 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
+		}
+
+		if len(excludedChecks) > 0 {
+			excludedChecksList = strings.Split(excludedChecks, ",")
 		}
 
 		formatter, err := getFormatter()

--- a/internal/app/tfsec/module_scan_test.go
+++ b/internal/app/tfsec/module_scan_test.go
@@ -37,7 +37,7 @@ resource "problem" "uhoh" {}
 			if err != nil {
 				t.Fatal(err)
 			}
-			results := scanner.New().Scan(blocks)
+			results := scanner.New().Scan(blocks, excludedChecksList)
 			assertCheckCode(t, test.mustIncludeResultCode, test.mustExcludeResultCode, results)
 		})
 	}

--- a/internal/app/tfsec/scanner/scanner.go
+++ b/internal/app/tfsec/scanner/scanner.go
@@ -1,4 +1,5 @@
 package scanner
+package scanner
 
 import (
 	"fmt"
@@ -17,15 +18,26 @@ func New() *Scanner {
 	return &Scanner{}
 }
 
+// Find element in list
+func checkInList(code RuleID, list []string) bool {
+	codeCurrent := fmt.Sprintf("%s", code)
+	for _, codeIgnored := range list {
+		if codeIgnored == codeCurrent {
+			return true
+		}
+	}
+	return false
+}
+
 // Scan takes all available hcl blocks and an optional context, and returns a slice of results. Each result indicates a potential security problem.
-func (scanner *Scanner) Scan(blocks []*parser.Block) []Result {
+func (scanner *Scanner) Scan(blocks []*parser.Block, excludedChecksList []string) []Result {
 	var results []Result
 	context := &Context{blocks: blocks}
 	for _, block := range blocks {
 		for _, check := range GetRegisteredChecks() {
 			if check.IsRequiredForBlock(block) {
 				for _, result := range check.Run(block, context) {
-					if !scanner.checkRangeIgnored(result.RuleID, result.Range) {
+					if !scanner.checkRangeIgnored(result.RuleID, result.Range) && !checkInList(result.RuleID, excludedChecksList) {
 						result.Link = fmt.Sprintf("https://github.com/liamg/tfsec/wiki/%s", result.RuleID)
 						results = append(results, result)
 					}

--- a/internal/app/tfsec/scanner/scanner.go
+++ b/internal/app/tfsec/scanner/scanner.go
@@ -1,5 +1,4 @@
 package scanner
-package scanner
 
 import (
 	"fmt"

--- a/internal/app/tfsec/setup_test.go
+++ b/internal/app/tfsec/setup_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 const exampleCheckCode scanner.RuleID = "EXA001"
+var excludedChecksList []string
 
 func TestMain(t *testing.M) {
 
@@ -32,7 +33,7 @@ func TestMain(t *testing.M) {
 
 func scanSource(source string) []scanner.Result {
 	blocks := createBlocksFromSource(source)
-	return scanner.New().Scan(blocks)
+	return scanner.New().Scan(blocks, excludedChecksList)
 }
 
 func createBlocksFromSource(source string) []*parser.Block {


### PR DESCRIPTION
Hi Liam,

please consider my PR to add new argument to disable/ignore provided checks globally in whole project. Idea is to turn off/skip checks which generate False Positive findings for particular repository

Possible scenarios where this can help:
1. GEN003 finds issues in standard K8S secret manager resources
2. Disable other unused Cloud Providers

Thanks