### PR TITLE
fix: defend against infinite traversal for local modules

### DIFF
--- a/internal/app/tfsec/parser/parser.go
+++ b/internal/app/tfsec/parser/parser.go
@@ -352,7 +352,7 @@ func (p pathBreaker) add(path string) {
 	p[path] = struct{}{}
 }
 
-// haveSeen returns a boolean denoting if we've seen the given path before.
+// hasSeen returns a boolean denoting if we've seen the given path before.
 func (p pathBreaker) hasSeen(path string) bool {
 	_, ok := p[path]
 	return ok

--- a/internal/app/tfsec/parser/parser_test.go
+++ b/internal/app/tfsec/parser/parser_test.go
@@ -120,6 +120,58 @@ output "result" {
 	value = var.input
 }
 `,
+		"module",
+	)
+
+	parser := New()
+
+	blocks, err := parser.ParseDirectory(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	modules := blocks.OfType("module")
+	require.Len(t, modules, 1)
+	module := modules[0]
+	assert.Equal(t, "module", module.Type())
+	assert.Equal(t, "module.my-mod", module.Name())
+	inputAttr := module.GetAttribute("input")
+	require.NotNil(t, inputAttr)
+	require.Equal(t, cty.String, inputAttr.Value().Type())
+	assert.Equal(t, "ok", inputAttr.Value().AsString())
+
+	outputs := blocks.OfType("output")
+	require.Len(t, outputs, 1)
+	output := outputs[0]
+	assert.Equal(t, "output.result", output.Name())
+	valAttr := output.GetAttribute("value")
+	require.NotNil(t, valAttr)
+	require.Equal(t, cty.String, valAttr.Type())
+	assert.Equal(t, "ok", valAttr.Value().AsString())
+}
+
+func Test_NestedParentModule(t *testing.T) {
+
+	path := createTestFileWithModule(`
+module "my-mod" {
+	source = "../."
+	input = "ok"
+}
+
+output "result" {
+	value = module.my-mod.result
+}
+`,
+		`
+variable "input" {
+	default = "?"
+}
+
+output "result" {
+	value = var.input
+}
+`,
+		"",
 	)
 
 	parser := New()
@@ -161,21 +213,26 @@ func createTestFile(filename, contents string) string {
 	return path
 }
 
-func createTestFileWithModule(contents string, moduleContents string) string {
+func createTestFileWithModule(contents string, moduleContents string, moduleName string) string {
 	dir, err := ioutil.TempDir(os.TempDir(), "tfsec")
 	if err != nil {
 		panic(err)
 	}
 
 	rootPath := filepath.Join(dir, "main")
-	modulePath := filepath.Join(dir, "module")
+	modulePath := dir
+	if len(moduleName) > 0 {
+		modulePath = filepath.Join(modulePath, moduleName)
+	}
 
 	if err := os.Mkdir(rootPath, 0755); err != nil {
 		panic(err)
 	}
 
-	if err := os.Mkdir(modulePath, 0755); err != nil {
-		panic(err)
+	if modulePath != dir {
+		if err := os.Mkdir(modulePath, 0755); err != nil {
+			panic(err)
+		}
 	}
 
 	if err := ioutil.WriteFile(filepath.Join(rootPath, "main.tf"), []byte(contents), 0755); err != nil {


### PR DESCRIPTION
This fixes #52 . The details on the thread were immensely helpful for identifying the issues here.

There were two separate bugs:

1. We were not correctly setting the filepath for all local module references. The `source` for modules was working only when the path pointed to a sibling or child directory (a common use-case). However, if it referenced a parent directory, this would break the parsing directory traversal logic.
2. As we didn't pass any state to the recursive parsing, this opened up the potential for an infinite loop. A situation that could cause this is the following directory structure:

```
/my-module
    fileA
    fileB
    examples/
        simple/
            main.tf // <--- where source = "../.."
```

This PR addresses the first issue by determining when we've set the wrong path and correcting it. It solves the second issue by introducing a mechanism for tracking state for "known" module paths.

Let me know y'alls thoughts on this - I wasn't super excited to introduce a new concept to the library `pathBreaker` (for circuit breaking), but it was the cleanest, minimal addition I could arrive at.