### PR TITLE
Add junit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ American friends).
 
 ## Output options
 
-You can output tfsec results as JSON, CSV, Checkstyle or just plain old human readable format. Use the `--format` flag 
+You can output tfsec results as JSON, CSV, Checkstyle, JUnit or just plain old human readable format. Use the `--format` flag 
 to specify your desired format.
 
 ## Support for older terraform versions

--- a/cmd/tfsec/main.go
+++ b/cmd/tfsec/main.go
@@ -24,7 +24,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&disableColours, "no-colour", disableColours, "Disable coloured output")
 	rootCmd.Flags().BoolVar(&disableColours, "no-color", disableColours, "Disable colored output (American style!)")
 	rootCmd.Flags().BoolVarP(&showVersion, "version", "v", showVersion, "Show version information and exit")
-	rootCmd.Flags().StringVarP(&format, "format", "f", format, "Select output format: default, json, csv, checkstyle")
+	rootCmd.Flags().StringVarP(&format, "format", "f", format, "Select output format: default, json, csv, checkstyle, junit")
 }
 
 func main() {
@@ -99,6 +99,8 @@ func getFormatter() (func([]scanner.Result) error, error) {
 		return formatters.FormatCSV, nil
 	case "checkstyle":
 		return formatters.FormatCheckStyle, nil
+	case "junit":
+		return formatters.FormatJUnit, nil
 	default:
 		return nil, fmt.Errorf("invalid format specified: '%s'", format)
 	}

--- a/internal/app/tfsec/formatters/junit.go
+++ b/internal/app/tfsec/formatters/junit.go
@@ -1,0 +1,108 @@
+package formatters
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/liamg/tfsec/internal/app/tfsec/scanner"
+)
+
+// see https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd
+// tested with CircleCI
+
+// JUnitTestSuite is a single JUnit test suite which may contain many
+// testcases.
+type JUnitTestSuite struct {
+	XMLName    xml.Name        `xml:"testsuite"`
+	Name       string          `xml:"name,attr"`
+	TestCases  []JUnitTestCase `xml:"testcase"`
+}
+
+// JUnitTestCase is a single test case with its result.
+type JUnitTestCase struct {
+	XMLName     xml.Name          `xml:"testcase"`
+	Classname   string            `xml:"classname,attr"`
+	Name        string            `xml:"name,attr"`
+	Time        string            `xml:"time,attr"`
+	Failure     *JUnitFailure     `xml:"failure,omitempty"`
+}
+
+// JUnitFailure contains data related to a failed test.
+type JUnitFailure struct {
+	Message  string `xml:"message,attr"`
+	Type     string `xml:"type,attr"`
+	Contents string `xml:",chardata"`
+}
+
+func FormatJUnit(results []scanner.Result) error {
+
+	output := JUnitTestSuite {
+		Name:"tfsec",
+	}
+
+	for _, result := range results {
+		output.TestCases = append(output.TestCases,
+			JUnitTestCase  {
+				Classname: result.Range.Filename,
+				Name: fmt.Sprintf("[%s][%s]", result.RuleID, result.Severity),
+				Time: "0",
+				Failure:
+				&JUnitFailure {
+					Message: result.Description,
+					Contents:  fmt.Sprintf("%s\n%s\nMore information: %s",
+						result.Range.String(),
+						highlightCodeJunit(result),
+						result.Link),
+				},
+			},
+		)
+	}
+
+	data, err := xml.MarshalIndent(output, "", "\t")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(xml.Header)
+	fmt.Println(string(data))
+	return nil
+}
+
+// highlight the lines of code which caused a problem, if available
+func highlightCodeJunit(result scanner.Result) string {
+
+	data, err := ioutil.ReadFile(result.Range.Filename)
+	if err != nil {
+		return ""
+	}
+
+	lines := append([]string{""}, strings.Split(string(data), "\n")...)
+
+	start := result.Range.StartLine - 3
+	if start <= 0 {
+		start = 1
+	}
+	end := result.Range.EndLine + 3
+	if end >= len(lines) {
+		end = len(lines) - 1
+	}
+
+	output:=""
+
+	for lineNo := start; lineNo <= end; lineNo++ {
+		output += fmt.Sprintf("  % 6d | ", lineNo)
+		if lineNo >= result.Range.StartLine && lineNo <= result.Range.EndLine {
+			if lineNo == result.Range.StartLine && result.RangeAnnotation != "" {
+				output += fmt.Sprintf("%    %s\n", lines[lineNo], result.RangeAnnotation)
+			} else {
+				output +=  fmt.Sprintf("%s\n", lines[lineNo])
+			}
+		} else {
+			output +=  fmt.Sprintf("%s\n", lines[lineNo])
+		}
+	}
+
+	return output
+}

--- a/internal/app/tfsec/formatters/junit.go
+++ b/internal/app/tfsec/formatters/junit.go
@@ -95,7 +95,7 @@ func highlightCodeJunit(result scanner.Result) string {
 		output += fmt.Sprintf("  % 6d | ", lineNo)
 		if lineNo >= result.Range.StartLine && lineNo <= result.Range.EndLine {
 			if lineNo == result.Range.StartLine && result.RangeAnnotation != "" {
-				output += fmt.Sprintf("%    %s\n", lines[lineNo], result.RangeAnnotation)
+				output += fmt.Sprintf("%s    %s\n", lines[lineNo], result.RangeAnnotation)
 			} else {
 				output +=  fmt.Sprintf("%s\n", lines[lineNo])
 			}


### PR DESCRIPTION
This PR adds support for the JUNIT format used in the CircleCI and few other projects. 

This is how it looks now in the CirlcleCI: 

![image](https://user-images.githubusercontent.com/1388875/83309331-3ffa6000-a209-11ea-9d86-e0b1e0fe108f.png)

If you have CircleCI account you can see build (from the branch tfsec-demo) here: https://app.circleci.com/pipelines/github/samm-git/tfsec/4/workflows/9eccc711-dbd1-4d6b-b324-152f5c416094/jobs/4

This should also address https://github.com/liamg/tfsec/issues/85, but i do not have jenkins to test
