### PR TITLE
Remove extra quote in the help text

### DIFF
--- a/cmd/tfsec/main.go
+++ b/cmd/tfsec/main.go
@@ -29,7 +29,7 @@ func init() {
 	rootCmd.Flags().BoolVarP(&showVersion, "version", "v", showVersion, "Show version information and exit")
 	rootCmd.Flags().StringVarP(&format, "format", "f", format, "Select output format: default, json, csv, checkstyle, junit")
 	rootCmd.Flags().StringVarP(&excludedChecks, "exclude", "e", excludedChecks, "Provide checks via , without space to exclude from run.")
-  rootCmd.Flags().BoolVarP(&softFail, "soft-fail", "s", softFail, "'Runs checks but suppresses error code")
+  rootCmd.Flags().BoolVarP(&softFail, "soft-fail", "s", softFail, "Runs checks but suppresses error code")
 }
 
 func main() {


### PR DESCRIPTION
The --help shows an extra quote
```
      --no-color         Disable colored output (American style!)
      --no-colour        Disable coloured output
  -s, --soft-fail        'Runs checks but suppresses error code
```