### PR TITLE
CloudFront recommended Security Policy version is TLSv1.2_2019

### DIFF
--- a/internal/app/tfsec/aws_cloudfront_outdated_protocol_test.go
+++ b/internal/app/tfsec/aws_cloudfront_outdated_protocol_test.go
@@ -32,12 +32,12 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 			mustIncludeResultCode: checks.AWSCloudFrontOutdatedProtocol,
 		},
 		{
-			name: "check TLSv1.2_2018 not used",
+			name: "check TLSv1.2_2019 not used",
 			source: `
 resource "aws_cloudfront_distribution" "s3_distribution" {
   viewer_certificate {
     cloudfront_default_certificate = true
-	minimum_protocol_version = "TLSv1.1_2016"
+	minimum_protocol_version = "TLSv1.2_2018"
   }
 }`,
 			mustIncludeResultCode: checks.AWSCloudFrontOutdatedProtocol,

--- a/internal/app/tfsec/checks/aws_cloudfront_outdated_protocol.go
+++ b/internal/app/tfsec/checks/aws_cloudfront_outdated_protocol.go
@@ -36,10 +36,10 @@ func init() {
 						scanner.SeverityError,
 					),
 				}
-			} else if minVersion.Type() == cty.String && minVersion.Value().AsString() != "TLSv1.2_2018" {
+			} else if minVersion.Type() == cty.String && minVersion.Value().AsString() != "TLSv1.2_2019" {
 				return []scanner.Result{
 					check.NewResult(
-						fmt.Sprintf("Resource '%s' defines outdated SSL/TLS policies (not using TLSv1.2_2018)", block.Name()),
+						fmt.Sprintf("Resource '%s' defines outdated SSL/TLS policies (not using TLSv1.2_2019)", block.Name()),
 						minVersion.Range(),
 						scanner.SeverityError,
 					),


### PR DESCRIPTION
AWS recommends CloudFront security policy version **TLSv1.2_2019**.

![image](https://user-images.githubusercontent.com/8839280/93048878-d492ac00-f69a-11ea-81c5-538bc8592ace.png)

https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html

P.S. Thank you for your great tool!

P.S. I found another PR https://github.com/liamg/tfsec/pull/153 after creating this PR, but I am also modifying the test code, so please review it once.

Resolves https://github.com/liamg/tfsec/issues/152