### PR TITLE
Add RuleDescription and RuleProvider

### DIFF
--- a/internal/app/tfsec/checks/aws_acl.go
+++ b/internal/app/tfsec/checks/aws_acl.go
@@ -12,10 +12,13 @@ import (
 
 // AWSBadBucketACL See https://github.com/liamg/tfsec#included-checks for check info
 const AWSBadBucketACL scanner.RuleID = "AWS001"
+const AwsBadBucketACLDescription scanner.RuleDescription = "S3 Bucket has an ACL defined which allows public access."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AWSBadBucketACL,
+		Description:    AwsBadBucketACLDescription,
+		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_s3_bucket"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/aws_api_gateway_domain_name_missing_security_policy.go
+++ b/internal/app/tfsec/checks/aws_api_gateway_domain_name_missing_security_policy.go
@@ -9,10 +9,13 @@ import (
 
 // AWSApiGatewayDomainNameOutdatedSecurityPolicy See https://github.com/liamg/tfsec#included-checks for check info
 const AWSApiGatewayDomainNameOutdatedSecurityPolicy scanner.RuleID = "AWS025"
+const AWSApiGatewayDomainNameOutdatedSecurityPolicyDescription scanner.RuleDescription = "API Gateway domain name uses outdated SSL/TLS protocols."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AWSApiGatewayDomainNameOutdatedSecurityPolicy,
+		Description:    AWSApiGatewayDomainNameOutdatedSecurityPolicyDescription,
+		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_api_gateway_domain_name"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/aws_bucket_logging.go
+++ b/internal/app/tfsec/checks/aws_bucket_logging.go
@@ -10,10 +10,13 @@ import (
 
 // AWSNoBucketLogging See https://github.com/liamg/tfsec#included-checks for check info
 const AWSNoBucketLogging scanner.RuleID = "AWS002"
+const AWSNoBucketLoggingDescription scanner.RuleDescription = "S3 Bucket does not have logging enabled."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AWSNoBucketLogging,
+		Description:    AWSNoBucketLoggingDescription,
+		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_s3_bucket"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/aws_classic.go
+++ b/internal/app/tfsec/checks/aws_classic.go
@@ -10,10 +10,13 @@ import (
 
 // AWSClassicUsage See https://github.com/liamg/tfsec#included-checks for check info
 const AWSClassicUsage scanner.RuleID = "AWS003"
+const AWSClassicUsageDescription scanner.RuleDescription = "AWS Classic resource usage."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AWSClassicUsage,
+		Description:    AWSClassicUsageDescription,
+		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_db_security_group", "aws_redshift_security_group", "aws_elasticache_security_group"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/aws_cloudfront_outdated_protocol.go
+++ b/internal/app/tfsec/checks/aws_cloudfront_outdated_protocol.go
@@ -9,10 +9,13 @@ import (
 
 // AWSCloudFrontOutdatedProtocol see https://github.com/liamg/tfsec#included-checks for check info
 const AWSCloudFrontOutdatedProtocol scanner.RuleID = "AWS021"
+const AWSCloudFrontOutdatedProtocolDescription scanner.RuleDescription = "CloudFront distribution uses outdated SSL/TSL protocols."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AWSCloudFrontOutdatedProtocol,
+		Description:    AWSCloudFrontOutdatedProtocolDescription,
+		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_cloudfront_distribution"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, context *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/aws_ecr_image_scan.go
+++ b/internal/app/tfsec/checks/aws_ecr_image_scan.go
@@ -12,10 +12,13 @@ import (
 
 // AWSEcrImageScanNotEnabled See https://github.com/liamg/tfsec#included-checks for check info
 const AWSEcrImageScanNotEnabled scanner.RuleID = "AWS023"
+const AWSEcrImageScanNotEnabledDescription scanner.RuleDescription = "ECR repository has image scans disabled."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AWSEcrImageScanNotEnabled,
+		Description:    AWSEcrImageScanNotEnabledDescription,
+		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_ecr_repository"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, context *scanner.Context) []scanner.Result {
@@ -23,7 +26,7 @@ func init() {
 			ecrScanStatusBlock := block.GetBlock("image_scanning_configuration")
 			ecrScanStatusAttr := ecrScanStatusBlock.GetAttribute("scan_on_push")
 
-			if ecrScanStatusAttr == nil  {
+			if ecrScanStatusAttr == nil {
 				return []scanner.Result{
 					check.NewResult(
 						fmt.Sprintf("Resource '%s' defines a disabled ECR image scan.", block.Name()),

--- a/internal/app/tfsec/checks/aws_http.go
+++ b/internal/app/tfsec/checks/aws_http.go
@@ -11,10 +11,13 @@ import (
 
 // AWSPlainHTTP See https://github.com/liamg/tfsec#included-checks for check info
 const AWSPlainHTTP scanner.RuleID = "AWS004"
+const AWSPlainHTTPDescription scanner.RuleDescription = "Use of plain HTTP."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AWSPlainHTTP,
+		Description:    AWSPlainHTTPDescription,
+		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_lb_listener", "aws_alb_listener"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/aws_missing_description_in_security_group.go
+++ b/internal/app/tfsec/checks/aws_missing_description_in_security_group.go
@@ -11,10 +11,13 @@ import (
 
 // AWSNoDescriptionInSecurityGroup See https://github.com/liamg/tfsec#included-checks for check info
 const AWSNoDescriptionInSecurityGroup scanner.RuleID = "AWS018"
+const AWSNoDescriptionInSecurityGroupDescription scanner.RuleDescription = "Missing description for security group/security group rule."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AWSNoDescriptionInSecurityGroup,
+		Description:    AWSNoDescriptionInSecurityGroupDescription,
+		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_security_group", "aws_security_group_rule"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/aws_no_kms_key_autorotate.go
+++ b/internal/app/tfsec/checks/aws_no_kms_key_autorotate.go
@@ -11,10 +11,13 @@ import (
 
 // AWSNoKMSAutoRotate See https://github.com/liamg/tfsec#included-checks for check info
 const AWSNoKMSAutoRotate scanner.RuleID = "AWS019"
+const AWSNoKMSAutoRotateDescription scanner.RuleDescription = "A KMS key is not configured to auto-rotate."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AWSNoKMSAutoRotate,
+		Description:    AWSNoKMSAutoRotateDescription,
+		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_kms_key"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/aws_not_internal.go
+++ b/internal/app/tfsec/checks/aws_not_internal.go
@@ -12,10 +12,13 @@ import (
 
 // AWSExternallyExposedLoadBalancer See https://github.com/liamg/tfsec#included-checks for check info
 const AWSExternallyExposedLoadBalancer scanner.RuleID = "AWS005"
+const AWSExternallyExposedLoadBalancerDescription scanner.RuleDescription = "Load balancer is exposed to the internet."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AWSExternallyExposedLoadBalancer,
+		Description:    AWSExternallyExposedLoadBalancerDescription,
+		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_alb", "aws_elb", "aws_lb"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/aws_open_security_group_rules.go
+++ b/internal/app/tfsec/checks/aws_open_security_group_rules.go
@@ -13,13 +13,17 @@ import (
 
 // AWSOpenIngressSecurityGroupRule See https://github.com/liamg/tfsec#included-checks for check info
 const AWSOpenIngressSecurityGroupRule scanner.RuleID = "AWS006"
+const AWSOpenIngressSecurityGroupRuleDescription scanner.RuleDescription = "An ingress security group rule allows traffic from `/0`."
 
 // AWSOpenEgressSecurityGroupRule See https://github.com/liamg/tfsec#included-checks for check info
 const AWSOpenEgressSecurityGroupRule scanner.RuleID = "AWS007"
+const AWSOpenEgressSecurityGroupRuleDescription scanner.RuleDescription = "An egress security group rule allows traffic to `/0`."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AWSOpenIngressSecurityGroupRule,
+		Description:    AWSOpenIngressSecurityGroupRuleDescription,
+		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_security_group_rule"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
@@ -80,6 +84,8 @@ func init() {
 
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AWSOpenEgressSecurityGroupRule,
+		Description:    AWSOpenEgressSecurityGroupRuleDescription,
+		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_security_group_rule"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/aws_open_security_groups.go
+++ b/internal/app/tfsec/checks/aws_open_security_groups.go
@@ -11,13 +11,17 @@ import (
 
 // AWSOpenIngressSecurityGroupInlineRule See https://github.com/liamg/tfsec#included-checks for check info
 const AWSOpenIngressSecurityGroupInlineRule scanner.RuleID = "AWS008"
+const AWSOpenIngressSecurityGroupInlineRuleDescription scanner.RuleDescription = "An inline ingress security group rule allows traffic from `/0`."
 
 // AWSOpenEgressSecurityGroupInlineRule See https://github.com/liamg/tfsec#included-checks for check info
 const AWSOpenEgressSecurityGroupInlineRule scanner.RuleID = "AWS009"
+const AWSOpenEgressSecurityGroupInlineRuleDescription scanner.RuleDescription = "An inline egress security group rule allows traffic to `/0`."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AWSOpenIngressSecurityGroupInlineRule,
+		Description:    AWSOpenIngressSecurityGroupInlineRuleDescription,
+		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_security_group"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
@@ -69,6 +73,8 @@ func init() {
 
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AWSOpenEgressSecurityGroupInlineRule,
+		Description:    AWSOpenEgressSecurityGroupInlineRuleDescription,
+		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_security_group"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/aws_oudated_tls_policy_elasticsearch_domain_endpoint.go
+++ b/internal/app/tfsec/checks/aws_oudated_tls_policy_elasticsearch_domain_endpoint.go
@@ -12,10 +12,13 @@ import (
 // AWSOutdatedTLSPolicyElasticsearchDomainEndpoint See
 // https://github.com/liamg/tfsec#included-checks for check info
 const AWSOutdatedTLSPolicyElasticsearchDomainEndpoint scanner.RuleID = "AWS034"
+const AWSOutdatedTLSPolicyElasticsearchDomainEndpointDescription scanner.RuleDescription = "Elasticsearch domain endpoint is using outdated TLS policy."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AWSOutdatedTLSPolicyElasticsearchDomainEndpoint,
+		Description:    AWSOutdatedTLSPolicyElasticsearchDomainEndpointDescription,
+		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_elasticsearch_domain"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, context *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/aws_outdated_ssl.go
+++ b/internal/app/tfsec/checks/aws_outdated_ssl.go
@@ -12,6 +12,7 @@ import (
 
 // AWSOutdatedSSLPolicy See https://github.com/liamg/tfsec#included-checks for check info
 const AWSOutdatedSSLPolicy scanner.RuleID = "AWS010"
+const AWSOutdatedSSLPolicyDescription scanner.RuleDescription = "An outdated SSL policy is in use by a load balancer."
 
 var outdatedSSLPolicies = []string{
 	"ELBSecurityPolicy-2015-05",
@@ -23,6 +24,8 @@ var outdatedSSLPolicies = []string{
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AWSOutdatedSSLPolicy,
+		Description:    AWSOutdatedSSLPolicyDescription,
+		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_lb_listener", "aws_alb_listener"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/aws_plaintext_node_to_node_elasticsearch_traffic.go
+++ b/internal/app/tfsec/checks/aws_plaintext_node_to_node_elasticsearch_traffic.go
@@ -11,10 +11,13 @@ import (
 
 // AWSPlaintextNodeToNodeElasticsearchTraffic See https://github.com/liamg/tfsec#included-checks for check info
 const AWSPlaintextNodeToNodeElasticsearchTraffic scanner.RuleID = "AWS032"
+const AWSPlaintextNodeToNodeElasticsearchTrafficDescription scanner.RuleDescription = "Elasticsearch domain uses plaintext traffic for node to node communication."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AWSPlaintextNodeToNodeElasticsearchTraffic,
+		Description:    AWSPlaintextNodeToNodeElasticsearchTrafficDescription,
+		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_elasticsearch_domain"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, context *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/aws_public.go
+++ b/internal/app/tfsec/checks/aws_public.go
@@ -12,10 +12,13 @@ import (
 
 // AWSPubliclyAccessibleResource See https://github.com/liamg/tfsec#included-checks for check info
 const AWSPubliclyAccessibleResource scanner.RuleID = "AWS011"
+const AWSPubliclyAccessibleResourceDescription scanner.RuleDescription = "A resource is marked as publicly accessible."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AWSPubliclyAccessibleResource,
+		Description:    AWSPubliclyAccessibleResourceDescription,
+		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_db_instance", "aws_dms_replication_instance", "aws_rds_cluster_instance", "aws_redshift_cluster"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/aws_public_ip.go
+++ b/internal/app/tfsec/checks/aws_public_ip.go
@@ -12,10 +12,13 @@ import (
 
 // AWSResourceHasPublicIP See https://github.com/liamg/tfsec#included-checks for check info
 const AWSResourceHasPublicIP scanner.RuleID = "AWS012"
+const AWSResourceHasPublicIPDescription scanner.RuleDescription = "A resource has a public IP address."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AWSResourceHasPublicIP,
+		Description:    AWSResourceHasPublicIPDescription,
+		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_launch_configuration", "aws_instance"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/aws_task_definition_includes_sensitive_data.go
+++ b/internal/app/tfsec/checks/aws_task_definition_includes_sensitive_data.go
@@ -15,10 +15,13 @@ import (
 
 // AWSTaskDefinitionWithSensitiveEnvironmentVariables See https://github.com/liamg/tfsec#included-checks for check info
 const AWSTaskDefinitionWithSensitiveEnvironmentVariables scanner.RuleID = "AWS013"
+const AWSTaskDefinitionWithSensitiveEnvironmentVariablesDescription scanner.RuleDescription = "Task definition defines sensitive environment variable(s)."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AWSTaskDefinitionWithSensitiveEnvironmentVariables,
+		Description:    AWSTaskDefinitionWithSensitiveEnvironmentVariablesDescription,
+		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_ecs_task_definition"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/aws_unencrypted_at_rest_elasticache_replication_group.go
+++ b/internal/app/tfsec/checks/aws_unencrypted_at_rest_elasticache_replication_group.go
@@ -10,10 +10,13 @@ import (
 
 // AWSUnencryptedAtRestElasticacheReplicationGroup See https://github.com/liamg/tfsec#included-checks for check info
 const AWSUnencryptedAtRestElasticacheReplicationGroup scanner.RuleID = "AWS035"
+const AWSUnencryptedAtRestElasticacheReplicationGroupDescription scanner.RuleDescription = "Unencrypted Elasticache Replication Group."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AWSUnencryptedAtRestElasticacheReplicationGroup,
+		Description:    AWSUnencryptedAtRestElasticacheReplicationGroupDescription,
+		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_elasticache_replication_group"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, context *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/aws_unencrypted_block_device.go
+++ b/internal/app/tfsec/checks/aws_unencrypted_block_device.go
@@ -12,10 +12,13 @@ import (
 
 // AWSLaunchConfigurationWithUnencryptedBlockDevice See https://github.com/liamg/tfsec#included-checks for check info
 const AWSLaunchConfigurationWithUnencryptedBlockDevice scanner.RuleID = "AWS014"
+const AWSLaunchConfigurationWithUnencryptedBlockDeviceDescription scanner.RuleDescription = "Launch configuration with unencrypted block device."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AWSLaunchConfigurationWithUnencryptedBlockDevice,
+		Description:    AWSLaunchConfigurationWithUnencryptedBlockDeviceDescription,
+		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_launch_configuration"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, context *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/aws_unencrypted_cloudfront_communications.go
+++ b/internal/app/tfsec/checks/aws_unencrypted_cloudfront_communications.go
@@ -12,10 +12,13 @@ import (
 
 // AWSUnencryptedCloudFrontCommunications See https://github.com/liamg/tfsec#included-checks for check info
 const AWSUnencryptedCloudFrontCommunications scanner.RuleID = "AWS020"
+const AWSUnencryptedCloudFrontCommunicationsDescription scanner.RuleDescription = "CloudFront distribution allows unencrypted (HTTP) communications."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AWSUnencryptedCloudFrontCommunications,
+		Description:    AWSUnencryptedCloudFrontCommunicationsDescription,
+		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_cloudfront_distribution"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, context *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/aws_unencrypted_elasticsearch_domain.go
+++ b/internal/app/tfsec/checks/aws_unencrypted_elasticsearch_domain.go
@@ -11,10 +11,13 @@ import (
 
 // AWSUnencryptedElasticsearchDomain See https://github.com/liamg/tfsec#included-checks for check info
 const AWSUnencryptedElasticsearchDomain scanner.RuleID = "AWS031"
+const AWSUnencryptedElasticsearchDomainDescription scanner.RuleDescription = "Elasticsearch domain isn't encrypted at rest."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AWSUnencryptedElasticsearchDomain,
+		Description:    AWSUnencryptedElasticsearchDomainDescription,
+		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_elasticsearch_domain"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, context *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/aws_unencrypted_in_transit_elasticache_replication_group.go
+++ b/internal/app/tfsec/checks/aws_unencrypted_in_transit_elasticache_replication_group.go
@@ -10,10 +10,13 @@ import (
 
 // AWSUnencryptedInTransitElasticacheReplicationGroup See https://github.com/liamg/tfsec#included-checks for check info
 const AWSUnencryptedInTransitElasticacheReplicationGroup scanner.RuleID = "AWS036"
+const AWSUnencryptedInTransitElasticacheReplicationGroupDescription scanner.RuleDescription = "Elasticache Replication Group uses unencrypted traffic."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AWSUnencryptedInTransitElasticacheReplicationGroup,
+		Description:    AWSUnencryptedInTransitElasticacheReplicationGroupDescription,
+		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_elasticache_replication_group"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, context *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/aws_unencrypted_kinesis_streams.go
+++ b/internal/app/tfsec/checks/aws_unencrypted_kinesis_streams.go
@@ -12,10 +12,13 @@ import (
 
 // AWSUnencryptedKinesisStream See https://github.com/liamg/tfsec#included-checks for check info
 const AWSUnencryptedKinesisStream scanner.RuleID = "AWS024"
+const AWSUnencryptedKinesisStreamDescription scanner.RuleDescription = "Kinesis stream is unencrypted."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AWSUnencryptedKinesisStream,
+		Description:    AWSUnencryptedKinesisStreamDescription,
+		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_kinesis_stream"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, context *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/aws_unencrypted_msk_broker_transit.go
+++ b/internal/app/tfsec/checks/aws_unencrypted_msk_broker_transit.go
@@ -10,10 +10,13 @@ import (
 
 // AWSUnencryptedMSKBroker See https://github.com/liamg/tfsec#included-checks for check info
 const AWSUnencryptedMSKBroker scanner.RuleID = "AWS022"
+const AWSUnencryptedMSKBrokerDescription scanner.RuleDescription = "A MSK cluster allows unencrypted data in transit."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AWSUnencryptedMSKBroker,
+		Description:    AWSUnencryptedMSKBrokerDescription,
+		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_msk_cluster"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, context *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/aws_unencrypted_s3_bucket.go
+++ b/internal/app/tfsec/checks/aws_unencrypted_s3_bucket.go
@@ -10,10 +10,13 @@ import (
 
 // AWSUnencryptedS3Bucket See https://github.com/liamg/tfsec#included-checks for check info
 const AWSUnencryptedS3Bucket scanner.RuleID = "AWS017"
+const AWSUnencryptedS3BucketDescription scanner.RuleDescription = "Unencrypted S3 bucket."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AWSUnencryptedS3Bucket,
+		Description:    AWSUnencryptedS3BucketDescription,
+		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_s3_bucket"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, context *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/aws_unencrypted_sns_topic.go
+++ b/internal/app/tfsec/checks/aws_unencrypted_sns_topic.go
@@ -12,10 +12,13 @@ import (
 
 // AWSUnencryptedSNSTopic See https://github.com/liamg/tfsec#included-checks for check info
 const AWSUnencryptedSNSTopic scanner.RuleID = "AWS016"
+const AWSUnencryptedSNSTopicDescription scanner.RuleDescription = "Unencrypted SNS topic."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AWSUnencryptedSNSTopic,
+		Description:    AWSUnencryptedSNSTopicDescription,
+		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_sns_topic"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, context *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/aws_unencrypted_sqs_queue.go
+++ b/internal/app/tfsec/checks/aws_unencrypted_sqs_queue.go
@@ -12,10 +12,13 @@ import (
 
 // AWSUnencryptedSQSQueue See https://github.com/liamg/tfsec#included-checks for check info
 const AWSUnencryptedSQSQueue scanner.RuleID = "AWS015"
+const AWSUnencryptedSQSQueueDescription scanner.RuleDescription = "Unencrypted SQS queue."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AWSUnencryptedSQSQueue,
+		Description:    AWSUnencryptedSQSQueueDescription,
+		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_sqs_queue"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, context *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/aws_unenforced_https_elasticsearch_domain_endpoint.go
+++ b/internal/app/tfsec/checks/aws_unenforced_https_elasticsearch_domain_endpoint.go
@@ -12,10 +12,13 @@ import (
 // AWSUnenforcedHTTPSElasticsearchDomainEndpoint See
 // https://github.com/liamg/tfsec#included-checks for check info
 const AWSUnenforcedHTTPSElasticsearchDomainEndpoint scanner.RuleID = "AWS033"
+const AWSUnenforcedHTTPSElasticsearchDomainEndpointDescription scanner.RuleDescription = "Elasticsearch doesn't enforce HTTPS traffic."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AWSUnenforcedHTTPSElasticsearchDomainEndpoint,
+		Description:    AWSUnenforcedHTTPSElasticsearchDomainEndpointDescription,
+		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_elasticsearch_domain"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, context *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/azurerm_open_network_security_rules.go
+++ b/internal/app/tfsec/checks/azurerm_open_network_security_rules.go
@@ -13,13 +13,17 @@ import (
 
 // AzureOpenInboundNetworkSecurityGroupRule See https://github.com/liamg/tfsec#included-checks for check info
 const AzureOpenInboundNetworkSecurityGroupRule scanner.RuleID = "AZU001"
+const AzureOpenInboundNetworkSecurityGroupRuleDescription scanner.RuleDescription = "An inbound network security rule allows traffic from `/0`."
 
 // AzureOpenOutboundNetworkSecurityGroupRule See https://github.com/liamg/tfsec#included-checks for check info
 const AzureOpenOutboundNetworkSecurityGroupRule scanner.RuleID = "AZU002"
+const AzureOpenOutboundNetworkSecurityGroupRuleDescription scanner.RuleDescription = "An outbound network security rule allows traffic to `/0`."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AzureOpenInboundNetworkSecurityGroupRule,
+		Description:    AzureOpenInboundNetworkSecurityGroupRuleDescription,
+		Provider:       scanner.AzureProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_network_security_rule"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
@@ -74,6 +78,8 @@ func init() {
 
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AzureOpenOutboundNetworkSecurityGroupRule,
+		Description:    AzureOpenOutboundNetworkSecurityGroupRuleDescription,
+		Provider:       scanner.AzureProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_network_security_rule"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/azurerm_unencrypted_data_lake_store.go
+++ b/internal/app/tfsec/checks/azurerm_unencrypted_data_lake_store.go
@@ -11,10 +11,13 @@ import (
 
 // AzureUnencryptedDataLakeStore See https://github.com/liamg/tfsec#included-checks for check info
 const AzureUnencryptedDataLakeStore scanner.RuleID = "AZU004"
+const AzureUnencryptedDataLakeStoreDescription scanner.RuleDescription = "Unencrypted data lake store."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AzureUnencryptedDataLakeStore,
+		Description:    AzureUnencryptedDataLakeStoreDescription,
+		Provider:       scanner.AzureProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_data_lake_store"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/azurerm_unencrypted_managed_disk.go
+++ b/internal/app/tfsec/checks/azurerm_unencrypted_managed_disk.go
@@ -12,10 +12,13 @@ import (
 
 // AzureUnencryptedManagedDisk See https://github.com/liamg/tfsec#included-checks for check info
 const AzureUnencryptedManagedDisk scanner.RuleID = "AZU003"
+const AzureUnencryptedManagedDiskDescription scanner.RuleDescription = "Unencrypted managed disk."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AzureUnencryptedManagedDisk,
+		Description:    AzureUnencryptedManagedDiskDescription,
+		Provider:       scanner.AzureProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_managed_disk"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/azurerm_virtual_machine_with_password_authentication.go
+++ b/internal/app/tfsec/checks/azurerm_virtual_machine_with_password_authentication.go
@@ -12,10 +12,13 @@ import (
 
 // AzureVMWithPasswordAuthentication See https://github.com/liamg/tfsec#included-checks for check info
 const AzureVMWithPasswordAuthentication scanner.RuleID = "AZU005"
+const AzureVMWithPasswordAuthenticationDescription scanner.RuleDescription = "Password authentication in use instead of SSH keys."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           AzureVMWithPasswordAuthentication,
+		Description:    AzureVMWithPasswordAuthenticationDescription,
+		Provider:       scanner.AzureProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_virtual_machine"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/generic_sensitive_attributes.go
+++ b/internal/app/tfsec/checks/generic_sensitive_attributes.go
@@ -13,6 +13,7 @@ import (
 
 // GenericSensitiveAttributes See https://github.com/liamg/tfsec#included-checks for check info
 const GenericSensitiveAttributes scanner.RuleID = "GEN003"
+const GenericSensitiveAttributesDescription scanner.RuleDescription = "Potentially sensitive data stored in block attribute."
 
 var sensitiveWhitelist = []struct {
 	Resource  string
@@ -31,6 +32,8 @@ var sensitiveWhitelist = []struct {
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:          GenericSensitiveAttributes,
+		Description:   GenericSensitiveAttributesDescription,
+		Provider:      scanner.GeneralProvider,
 		RequiredTypes: []string{"resource", "provider", "module"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
 

--- a/internal/app/tfsec/checks/generic_sensitive_locals.go
+++ b/internal/app/tfsec/checks/generic_sensitive_locals.go
@@ -13,10 +13,13 @@ import (
 
 // GenericSensitiveLocals See https://github.com/liamg/tfsec#included-checks for check info
 const GenericSensitiveLocals scanner.RuleID = "GEN002"
+const GenericSensitiveLocalsDescription scanner.RuleDescription = "Potentially sensitive data stored in local value."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:          GenericSensitiveLocals,
+		Description:   GenericSensitiveLocalsDescription,
+		Provider:      scanner.GeneralProvider,
 		RequiredTypes: []string{"locals"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
 

--- a/internal/app/tfsec/checks/generic_sensitive_variables.go
+++ b/internal/app/tfsec/checks/generic_sensitive_variables.go
@@ -13,10 +13,13 @@ import (
 
 // GenericSensitiveVariables See https://github.com/liamg/tfsec#included-checks for check info
 const GenericSensitiveVariables scanner.RuleID = "GEN001"
+const GenericSensitiveVariablesDescription scanner.RuleDescription = "Potentially sensitive data stored in \"default\" value of variable."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:          GenericSensitiveVariables,
+		Description:   GenericSensitiveVariablesDescription,
+		Provider:      scanner.GeneralProvider,
 		RequiredTypes: []string{"variable"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
 

--- a/internal/app/tfsec/checks/gke_abac_enabled.go
+++ b/internal/app/tfsec/checks/gke_abac_enabled.go
@@ -9,10 +9,13 @@ import (
 
 // GkeAbacEnabled See https://github.com/liamg/tfsec#included-checks for check info
 const GkeAbacEnabled scanner.RuleID = "GCP005"
+const GkeAbacEnabledDescription scanner.RuleDescription = "Legacy ABAC permissions are enabled."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           GkeAbacEnabled,
+		Description:    GkeAbacEnabledDescription,
+		Provider:       scanner.GCPProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"google_container_cluster"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/gke_enforce_psp.go
+++ b/internal/app/tfsec/checks/gke_enforce_psp.go
@@ -10,10 +10,13 @@ import (
 
 // GkeEnforcePSP See https://github.com/liamg/tfsec#included-checks for check info
 const GkeEnforcePSP scanner.RuleID = "GCP009"
+const GkeEnforcePSPDescription scanner.RuleDescription = "Pod security policy enforcement not defined."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           GkeEnforcePSP,
+		Description:    GkeEnforcePSPDescription,
+		Provider:       scanner.GCPProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"google_container_cluster"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
@@ -30,7 +33,7 @@ func init() {
 			}
 
 			enforcePSP := pspBlock.GetAttribute("enabled")
-      if enforcePSP.Type() == cty.Bool && enforcePSP.Value().False() || enforcePSP.Type() == cty.String && enforcePSP.Value().AsString() != "true" {
+			if enforcePSP.Type() == cty.Bool && enforcePSP.Value().False() || enforcePSP.Type() == cty.String && enforcePSP.Value().AsString() != "true" {
 				return []scanner.Result{
 					check.NewResult(
 						fmt.Sprintf("Resource '%s' defines a cluster with Pod Security Policy enforcement disabled. It is recommended to define a PSP for your pods and enable PSP enforcement. https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#admission_controllers", block.Name()),

--- a/internal/app/tfsec/checks/gke_legacy_auth_enabled.go
+++ b/internal/app/tfsec/checks/gke_legacy_auth_enabled.go
@@ -12,10 +12,13 @@ import (
 
 // GkeLegacyAuthEnabled See https://github.com/liamg/tfsec#included-checks for check info
 const GkeLegacyAuthEnabled scanner.RuleID = "GCP008"
+const GkeLegacyAuthEnabledDescription scanner.RuleDescription = "Legacy client authentication methods utilized."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           GkeLegacyAuthEnabled,
+		Description:    GkeLegacyAuthEnabledDescription,
+		Provider:       scanner.GCPProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"google_container_cluster"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/gke_legacy_metadata_endpoints.go
+++ b/internal/app/tfsec/checks/gke_legacy_metadata_endpoints.go
@@ -12,16 +12,19 @@ import (
 
 // GkeLegacyMetadataEndpoints See https://github.com/liamg/tfsec#included-checks for check info
 const GkeLegacyMetadataEndpoints scanner.RuleID = "GCP007"
+const GkeLegacyMetadataEndpointsDescription scanner.RuleDescription = "Legacy metadata endpoints enabled."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           GkeLegacyMetadataEndpoints,
+		Description:    GkeLegacyMetadataEndpointsDescription,
+		Provider:       scanner.GCPProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"google_container_cluster"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
 
 			legacyMetadataAPI := block.GetBlock("metadata").GetAttribute("disable-legacy-endpoints")
-      if legacyMetadataAPI.Type() == cty.String && legacyMetadataAPI.Value().AsString() != "true" || legacyMetadataAPI.Type() == cty.Bool && legacyMetadataAPI.Value().False() {
+			if legacyMetadataAPI.Type() == cty.String && legacyMetadataAPI.Value().AsString() != "true" || legacyMetadataAPI.Type() == cty.Bool && legacyMetadataAPI.Value().False() {
 				return []scanner.Result{
 					check.NewResult(
 						fmt.Sprintf("Resource '%s' defines a cluster with legacy metadata endpoints enabled. See: https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#protect_node_metadata_default_for_112", block.Name()),

--- a/internal/app/tfsec/checks/gke_node_metadata_exposed.go
+++ b/internal/app/tfsec/checks/gke_node_metadata_exposed.go
@@ -2,7 +2,6 @@ package checks
 
 import (
 	"fmt"
-
 	"github.com/liamg/tfsec/internal/app/tfsec/parser"
 
 	"github.com/liamg/tfsec/internal/app/tfsec/scanner"
@@ -12,17 +11,20 @@ import (
 
 // GkeNodeMetadataExposed See https://github.com/liamg/tfsec#included-checks for check info
 const GkeNodeMetadataExposed scanner.RuleID = "GCP006"
+const GkeNodeMetadataExposedDescription scanner.RuleDescription = "Node metadata value disables metadata concealment."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           GkeNodeMetadataExposed,
+		Description:    GkeNodeMetadataExposedDescription,
+		Provider:       scanner.GCPProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"google_container_cluster"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
 
 			nodeMetadata := block.GetBlock("workload_metadata_config").GetAttribute("node_metadata")
 
-      if nodeMetadata.Type() == cty.String && nodeMetadata.Value().AsString() == "EXPOSE" || nodeMetadata.Type() == cty.String && nodeMetadata.Value().AsString() == "UNSPECIFIED" {
+			if nodeMetadata.Type() == cty.String && nodeMetadata.Value().AsString() == "EXPOSE" || nodeMetadata.Type() == cty.String && nodeMetadata.Value().AsString() == "UNSPECIFIED" {
 				return []scanner.Result{
 					check.NewResult(
 						fmt.Sprintf("Resource '%s' defines a cluster with node metadata exposed. node_metadata set to EXPOSE or UNSPECIFIED disables metadata concealment. https://cloud.google.com/kubernetes-engine/docs/how-to/protecting-cluster-metadata#create-concealed", block.Name()),

--- a/internal/app/tfsec/checks/gke_shielded_nodes_disabled.go
+++ b/internal/app/tfsec/checks/gke_shielded_nodes_disabled.go
@@ -6,16 +6,19 @@ import (
 	"github.com/liamg/tfsec/internal/app/tfsec/parser"
 
 	"github.com/liamg/tfsec/internal/app/tfsec/scanner"
-	
+
 	"github.com/zclconf/go-cty/cty"
 )
 
 // GkeShieldedNodesDisabled See https://github.com/liamg/tfsec#included-checks for check info
 const GkeShieldedNodesDisabled scanner.RuleID = "GCP010"
+const GkeShieldedNodesDisabledDescription scanner.RuleDescription = "Shielded GKE nodes not enabled."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           GkeShieldedNodesDisabled,
+		Description:    GkeShieldedNodesDisabledDescription,
+		Provider:       scanner.GCPProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"google_container_cluster"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/google_open_firewall_rules.go
+++ b/internal/app/tfsec/checks/google_open_firewall_rules.go
@@ -11,13 +11,17 @@ import (
 
 // GoogleOpenInboundFirewallRule See https://github.com/liamg/tfsec#included-checks for check info
 const GoogleOpenInboundFirewallRule scanner.RuleID = "GCP003"
+const GoogleOpenInboundFirewallRuleDescription scanner.RuleDescription = "An inbound firewall rule allows traffic from `/0`."
 
 // GoogleOpenOutboundFirewallRule See https://github.com/liamg/tfsec#included-checks for check info
 const GoogleOpenOutboundFirewallRule scanner.RuleID = "GCP004"
+const GoogleOpenOutboundFirewallRuleDescription scanner.RuleDescription = "An outbound firewall rule allows traffic to `/0`."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           GoogleOpenInboundFirewallRule,
+		Description:    GoogleOpenInboundFirewallRuleDescription,
+		Provider:       scanner.GCPProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"google_compute_firewall"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
@@ -48,6 +52,7 @@ func init() {
 
 	scanner.RegisterCheck(scanner.Check{
 		Code:           GoogleOpenOutboundFirewallRule,
+		Description:    GoogleOpenOutboundFirewallRuleDescription,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"google_compute_firewall"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/google_unencrypted_disk.go
+++ b/internal/app/tfsec/checks/google_unencrypted_disk.go
@@ -9,10 +9,13 @@ import (
 
 // GoogleUnencryptedDisk See https://github.com/liamg/tfsec#included-checks for check info
 const GoogleUnencryptedDisk scanner.RuleID = "GCP001"
+const GoogleUnencryptedDiskDescription scanner.RuleDescription = "Unencrypted compute disk."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           GoogleUnencryptedDisk,
+		Description:    GoogleUnencryptedDiskDescription,
+		Provider:       scanner.GCPProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"google_compute_disk"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/google_unencrypted_storage_bucket.go
+++ b/internal/app/tfsec/checks/google_unencrypted_storage_bucket.go
@@ -9,10 +9,13 @@ import (
 
 // GoogleUnencryptedStorageBucket See https://github.com/liamg/tfsec#included-checks for check info
 const GoogleUnencryptedStorageBucket scanner.RuleID = "GCP002"
+const GoogleUnencryptedStorageBucketDescription scanner.RuleDescription = "Unencrypted storage bucket."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code:           GoogleUnencryptedStorageBucket,
+		Description:    GoogleUnencryptedStorageBucketDescription,
+		Provider:       scanner.GCPProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"google_storage_bucket"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {

--- a/internal/app/tfsec/checks/google_user_iam_grant.go
+++ b/internal/app/tfsec/checks/google_user_iam_grant.go
@@ -2,19 +2,22 @@ package checks
 
 import (
 	"fmt"
-	"strings"
 	"github.com/liamg/tfsec/internal/app/tfsec/parser"
 	"github.com/liamg/tfsec/internal/app/tfsec/scanner"
 	"github.com/zclconf/go-cty/cty"
+	"strings"
 )
 
 // GoogleUserIAMGrant See https://github.com/liamg/tfsec#included-checks for check info
 const GoogleUserIAMGrant scanner.RuleID = "GCP011"
+const GoogleUserIAMGrantDescription scanner.RuleDescription = "IAM granted directly to user."
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
-		Code:           GoogleUserIAMGrant,
-		RequiredTypes:  []string{"resource", "data"},
+		Code:          GoogleUserIAMGrant,
+		Description:   GoogleUserIAMGrantDescription,
+		Provider:      scanner.GCPProvider,
+		RequiredTypes: []string{"resource", "data"},
 		RequiredLabels: []string{
 			"google_cloud_run_service_iam_binding",
 			"google_cloud_run_service_iam_member",

--- a/internal/app/tfsec/scanner/check.go
+++ b/internal/app/tfsec/scanner/check.go
@@ -11,11 +11,22 @@ import (
 
 // RuleID is a unique identifier for a check
 type RuleID string
+type RuleDescription string
+type RuleProvider string
+
+const (
+	AWSProvider     RuleProvider = "aws"
+	AzureProvider   RuleProvider = "azurerm"
+	GCPProvider     RuleProvider = "google"
+	GeneralProvider RuleProvider = "*"
+)
 
 // Check is a targeted security test which can be applied to terraform templates. It includes the types to run on e.g.
 // "resource", and the labels to run on e.g. "aws_s3_bucket".
 type Check struct {
 	Code           RuleID
+	Description    RuleDescription
+	Provider       RuleProvider
 	RequiredTypes  []string
 	RequiredLabels []string
 	CheckFunc      func(*Check, *parser.Block, *Context) []Result


### PR DESCRIPTION
Add rule description and rule provider to the scanner.check to facilitate the generation of Check documentation and reporting.